### PR TITLE
Output enhancement

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -98,6 +98,12 @@ Workflow options:
     -g --graph
       Show links on graph pages.
 
+    --stacked
+      Output single link for the stacked graph of selected data.
+
+    --normal
+      Output single link for the normal (overlapping) graph of selected data.
+
   -G --groups
     Search and operate on configuration of users groups.
 
@@ -156,7 +162,8 @@ Options:
     -d --extended
   -L --latest-data
     -g --graph
-    -d --extended
+    --stacked
+    --normal
   -G --groups
     -a --add <user>
     -r --remove <user>

--- a/docs.go
+++ b/docs.go
@@ -83,6 +83,11 @@ Workflow options:
     -f --noconfirm
       Do not prompt acknowledge confirmation dialog.
 
+    -d --extended
+      Once for printing item's last value from the first component of the
+      trigger expression. Twice for adding last value change date. Thrice for
+      printing item description as well.
+
   -L --latest-data
     Search and show latest data for specified host(s). Hosts can be searched
     using wildcard character '*'.  Latest data can be filtered using /<pattern>
@@ -125,7 +130,7 @@ Misc options:
     Show version.
 `)
 	usage = `
-  zabbixctl [options] -T [-v]... [-x]... [<pattern>]...
+  zabbixctl [options] -T [-v]... [-x]... [-d]... [<pattern>]...
   zabbixctl [options] -L [-v]... <pattern>...
   zabbixctl [options] -G [-v]... [<pattern>]...
   zabbixctl [options] -G [-v]... <pattern>... -a <user>
@@ -148,8 +153,10 @@ Options:
     -n --limit <amount>  [default: 0]
     -f --noconfirm
     -k --acknowledge
+    -d --extended
   -L --latest-data
     -g --graph
+    -d --extended
   -G --groups
     -a --add <user>
     -r --remove <user>

--- a/docs.go
+++ b/docs.go
@@ -98,10 +98,10 @@ Workflow options:
     -g --graph
       Show links on graph pages.
 
-    --stacked
+    -w --stacked
       Output single link for the stacked graph of selected data.
 
-    --normal
+    -j --normal
       Output single link for the normal (overlapping) graph of selected data.
 
   -G --groups
@@ -144,7 +144,7 @@ Misc options:
   zabbixctl -h | --help
   zabbixctl --version
 `
-	options = `
+    options = `
 Options:
   -T --triggers
     -y --only-nack
@@ -162,8 +162,8 @@ Options:
     -d --extended
   -L --latest-data
     -g --graph
-    --stacked
-    --normal
+    -w --stacked
+    -j --normal
   -G --groups
     -a --add <user>
     -r --remove <user>

--- a/docs.go
+++ b/docs.go
@@ -101,7 +101,7 @@ Workflow options:
     -w --stacked
       Output single link for the stacked graph of selected data.
 
-    -j --normal
+    -b --normal
       Output single link for the normal (overlapping) graph of selected data.
 
   -G --groups
@@ -163,7 +163,7 @@ Options:
   -L --latest-data
     -g --graph
     -w --stacked
-    -j --normal
+    -b --normal
   -G --groups
     -a --add <user>
     -r --remove <user>

--- a/function.go
+++ b/function.go
@@ -1,0 +1,9 @@
+package main
+
+type Function struct {
+	ID        string `json:"functionid"`
+	ItemID    string `json:"itemid"`
+	TriggerID string `json:"triggerid"`
+	Name      string `json:"function"`
+	Parameter string `json:"parameter"`
+}

--- a/handle_latest_data.go
+++ b/handle_latest_data.go
@@ -17,6 +17,8 @@ func handleLatestData(
 	var (
 		hostnames, pattern = parseSearchQuery(args["<pattern>"].([]string))
 		graphs             = args["--graph"].(bool)
+		stackedGraph       = args["--stacked"].(bool)
+		normalGraph        = args["--normal"].(bool)
 		table              = tabwriter.NewWriter(os.Stdout, 1, 4, 2, ' ', 0)
 	)
 
@@ -85,6 +87,9 @@ func handleLatestData(
 		)
 	}
 
+	var (
+		matchedItemIDs = make([]string, 0)
+	)
 	for _, item := range items {
 		line := fmt.Sprintf(
 			"%s\t%s\t%s\t%-10s",
@@ -96,14 +101,27 @@ func handleLatestData(
 			continue
 		}
 
+		fmt.Fprint(table, line)
+
 		if graphs {
-			line = line + " " + zabbix.GetGraphURL(item.ID)
+			fmt.Fprintf(table, "\t%s", zabbix.GetGraphURL(item.ID))
 		}
 
-		fmt.Fprintln(table, line)
+		fmt.Fprint(table, "\n")
+
+		matchedItemIDs = append(matchedItemIDs, item.ID)
 	}
 
-	table.Flush()
+	switch {
+	case stackedGraph:
+		fmt.Println(zabbix.GetStackedGraphURL(matchedItemIDs))
+
+	case normalGraph:
+		fmt.Println(zabbix.GetNormalGraphURL(matchedItemIDs))
+
+	default:
+		table.Flush()
+	}
 
 	return nil
 }

--- a/handle_latest_data.go
+++ b/handle_latest_data.go
@@ -87,9 +87,8 @@ func handleLatestData(
 		)
 	}
 
-	var (
-		matchedItemIDs = make([]string, 0)
-	)
+	var matchedItemIDs = []string{}
+
 	for _, item := range items {
 		line := fmt.Sprintf(
 			"%s\t%s\t%s\t%-10s",

--- a/handle_latest_data.go
+++ b/handle_latest_data.go
@@ -88,7 +88,7 @@ func handleLatestData(
 	for _, item := range items {
 		line := fmt.Sprintf(
 			"%s\t%s\t%s\t%-10s",
-			hash[item.HostID].Name, item.Name,
+			hash[item.HostID].Name, item.Format(),
 			item.DateTime(), item.LastValue,
 		)
 

--- a/handle_triggers.go
+++ b/handle_triggers.go
@@ -185,7 +185,12 @@ func getTriggerItemsHistory(
 					"limit":   1,
 				})
 				if err != nil {
-					return err
+					return hierr.Errorf(
+						err,
+						`can't obtain history (type '%s') for item '%s'`,
+						item.ValueType,
+						item.ID,
+					)
 				}
 
 				if len(lastValues) == 0 {

--- a/handle_triggers.go
+++ b/handle_triggers.go
@@ -62,7 +62,7 @@ func handleTriggers(
 		)
 	}
 
-	var history = make(map[string]ItemHistory)
+	var history = map[string]ItemHistory{}
 
 	if extended != ExtendedOutputNone {
 		history, err = getTriggerItemsHistory(zabbix, triggers)

--- a/history.go
+++ b/history.go
@@ -27,5 +27,9 @@ func (history *History) date() time.Time {
 }
 
 func (history *History) DateTime() string {
+	if history.Clock == "0" {
+		return "-"
+	}
+
 	return history.date().Format("2006-01-02 15:04:05")
 }

--- a/history.go
+++ b/history.go
@@ -13,8 +13,8 @@ type History struct {
 }
 
 type ItemHistory struct {
-	Item    Item
-	History History
+	Item
+	History
 }
 
 func (history *History) String() string {

--- a/history.go
+++ b/history.go
@@ -6,12 +6,10 @@ import (
 	"time"
 )
 
-type HistoryValue interface{}
-
 type History struct {
-	ItemID string       `json:"itemid"`
-	Value  HistoryValue `json:"value"`
-	Clock  string       `json:"clock"`
+	ItemID string      `json:"itemid"`
+	Value  interface{} `json:"value"`
+	Clock  string      `json:"clock"`
 }
 
 type ItemHistory struct {

--- a/history.go
+++ b/history.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type HistoryValue interface{}
+
+type History struct {
+	ItemID string       `json:"itemid"`
+	Value  HistoryValue `json:"value"`
+	Clock  string       `json:"clock"`
+}
+
+type ItemHistory struct {
+	Item    Item
+	History History
+}
+
+func (history *History) String() string {
+	return fmt.Sprint(history.Value)
+}
+
+func (history *History) date() time.Time {
+	date, _ := strconv.ParseInt(history.Clock, 10, 64)
+	return time.Unix(date, 0)
+}
+
+func (history *History) DateTime() string {
+	return history.date().Format("2006-01-02 15:04:05")
+}

--- a/item.go
+++ b/item.go
@@ -1,14 +1,22 @@
 package main
 
 import (
+	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
+)
+
+var (
+	reItemKeyParams = regexp.MustCompile(`\[([^\]]+)\]`)
 )
 
 type Item struct {
 	ID         string `json:"itemid"`
 	HostID     string `json:"hostid"`
 	Name       string `json:"name"`
+	ValueType  string `json:"value_type"`
 	LastValue  string `json:"lastvalue"`
 	LastChange string `json:"lastclock"`
 	Key        string `json:"key_"`
@@ -25,4 +33,20 @@ func (item *Item) DateTime() string {
 func (item *Item) date() time.Time {
 	date, _ := strconv.ParseInt(item.LastChange, 10, 64)
 	return time.Unix(date, 0)
+}
+
+func (item *Item) Format() string {
+	name := item.Name
+
+	match := reItemKeyParams.FindStringSubmatch(item.Key)
+	if len(match) == 0 {
+		return name
+	}
+
+	args := strings.Split(match[1], ",")
+	for index, arg := range args {
+		name = strings.Replace(name, fmt.Sprintf(`$%d`, index+1), arg, -1)
+	}
+
+	return name
 }

--- a/item.go
+++ b/item.go
@@ -11,6 +11,7 @@ type Item struct {
 	Name       string `json:"name"`
 	LastValue  string `json:"lastvalue"`
 	LastChange string `json:"lastclock"`
+	Key        string `json:"key_"`
 }
 
 func (item *Item) DateTime() string {

--- a/man.1
+++ b/man.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZABBIXCTL" "1" "June 2016" "" ""
+.TH "ZABBIXCTL" "1" "July 2016" "" ""
 .
 .SH "NAME"
 \fBzabbixctl\fR \- tool for working with zabbix using command line interface
@@ -200,7 +200,7 @@ Show version\.
 .
 .nf
 
-zabbixctlp \-Tp
+zabbixctl \-Tp
 .
 .fi
 .
@@ -213,7 +213,7 @@ zabbixctlp \-Tp
 .
 .nf
 
-zabbixctlp \-Tr
+zabbixctl \-Tr
 .
 .fi
 .
@@ -226,7 +226,7 @@ zabbixctlp \-Tr
 .
 .nf
 
-zabbixctlp \-T /mysql
+zabbixctl \-T /mysql
 .
 .fi
 .
@@ -253,6 +253,19 @@ zabbixctl \-T \-xxxxx \-k
 .nf
 
 zabbixctl \-L dbnode* /lag
+.
+.fi
+.
+.IP "" 0
+.
+.P
+\fIOpening stacked graph for CPU quote use of selected containers\fR
+.
+.IP "" 4
+.
+.nf
+
+zabbixctl \-L \'container\-*\' /cpu quota \-\-stacked
 .
 .fi
 .
@@ -299,6 +312,9 @@ zabbixctl \-G /guest \-a admin
 .
 .SH "AUTHOR"
 Egor Kovetskiy \fIe\.kovetskiy@gmail\.com\fR
+.
+.SH "CONTRIBUTORS"
+Stanislav Seletskiy \fIs\.seletskiy@gmail\.com\fR
 .
 .P
 GitHub \fIhttps://github\.com/kovetskiy/zabbixctl\fR

--- a/man.markdown
+++ b/man.markdown
@@ -151,19 +151,19 @@ Show version.
 *Listing triggers in a problem state*
 
 ```
-zabbixctlp -Tp
+zabbixctl -Tp
 ```
 
 *Listing triggers that have recenty been in a problem state*
 
 ```
-zabbixctlp -Tr
+zabbixctl -Tr
 ```
 
 *Listing and filtering triggers that contain a word mysql*
 
 ```
-zabbixctlp -T /mysql
+zabbixctl -T /mysql
 ```
 
 *Listing and acknowledging triggers that severity level is DISASTER*
@@ -176,6 +176,12 @@ zabbixctl -T -xxxxx -k
 
 ```
 zabbixctl -L dbnode* /lag
+```
+
+*Opening stacked graph for CPU quote use of selected containers*
+
+```
+zabbixctl -L 'container-*' /cpu quota --stacked
 ```
 
 *Listing users groups that starts with 'HTTP_'*
@@ -199,5 +205,9 @@ zabbixctl -G /guest -a admin
 ## AUTHOR
 
 Egor Kovetskiy <e.kovetskiy@gmail.com>
+
+## CONTRIBUTORS
+
+Stanislav Seletskiy <s.seletskiy@gmail.com>
 
 [GitHub](https://github.com/kovetskiy/zabbixctl)

--- a/readme.markdown
+++ b/readme.markdown
@@ -111,6 +111,10 @@ Remove specified <user> from speicifed users group.
 ##### -f --noconfirm
 Do not prompt confirmation dialog.
 
+##### --stacked | --normal
+Returns single link which points to the stacked or normal graph for matched
+items.
+
 ## Examples
 
 ### Listing triggers in a problem state
@@ -141,6 +145,12 @@ zabbixctl -T -xxxxx -k
 
 ```
 zabbixctl -L dbnode* /lag
+```
+
+### Opening stacked graph for CPU quote use of selected containers
+
+```
+zabbixctl -L 'container-*' /cpu quota --stacked
 ```
 
 ### Listing users groups that starts with 'HTTP_'

--- a/readme.markdown
+++ b/readme.markdown
@@ -111,7 +111,7 @@ Remove specified <user> from speicifed users group.
 ##### -f --noconfirm
 Do not prompt confirmation dialog.
 
-##### --stacked | --normal
+##### -w --stacked | -b --normal
 Returns single link which points to the stacked or normal graph for matched
 items.
 

--- a/responses.go
+++ b/responses.go
@@ -55,3 +55,8 @@ type ResponseUsers struct {
 	ResponseRaw
 	Data []User `json:"result"`
 }
+
+type ResponseHistory struct {
+	ResponseRaw
+	Data []History `json:"result"`
+}

--- a/trigger.go
+++ b/trigger.go
@@ -7,11 +7,13 @@ import (
 )
 
 type Trigger struct {
-	ID          string `json:"triggerid"`
-	Description string `json:"description"`
-	Hostname    string `json:"host"`
-	Value       string `json:"value"`
-	LastChange  string `json:"lastchange"`
+	ID          string     `json:"triggerid"`
+	Description string     `json:"description"`
+	Hostname    string     `json:"host"`
+	Value       string     `json:"value"`
+	Comments    string     `json:"comments"`
+	Functions   []Function `json:"functions"`
+	LastChange  string     `json:"lastchange"`
 	LastEvent   struct {
 		ID           string `json:"eventid"`
 		Acknowledged string `json:"acknowledged"`

--- a/zabbix.go
+++ b/zabbix.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -323,8 +324,37 @@ func (zabbix *Zabbix) GetHosts(params Params) ([]Host, error) {
 }
 
 func (zabbix *Zabbix) GetGraphURL(identifier string) string {
-	return zabbix.basicURL +
-		"/history.php?action=showgraph&itemids%5B%5D=" + identifier
+	return zabbix.getGraphURL([]string{identifier}, "showgraph", "0")
+}
+
+func (zabbix *Zabbix) GetNormalGraphURL(identifiers []string) string {
+	return zabbix.getGraphURL(identifiers, "batchgraph", "0")
+}
+
+func (zabbix *Zabbix) GetStackedGraphURL(identifiers []string) string {
+	return zabbix.getGraphURL(identifiers, "batchgraph", "1")
+}
+
+func (zabbix *Zabbix) getGraphURL(
+	identifiers []string,
+	action string,
+	graphType string,
+) string {
+	encodedIdentifiers := []string{}
+
+	for _, identifier := range identifiers {
+		encodedIdentifiers = append(
+			encodedIdentifiers,
+			"itemids%5B%5D="+identifier,
+		)
+	}
+
+	return zabbix.basicURL + fmt.Sprintf(
+		"/history.php?action=%s&graphtype=%s&%s",
+		action,
+		graphType,
+		strings.Join(encodedIdentifiers, "&"),
+	)
 }
 
 func (zabbix *Zabbix) GetHistory(extend Params) ([]History, error) {

--- a/zabbix.go
+++ b/zabbix.go
@@ -335,7 +335,8 @@ func (zabbix *Zabbix) GetHosts(params Params) ([]Host, error) {
 }
 
 func (zabbix *Zabbix) GetGraphURL(identifier string) string {
-	return zabbix.basicURL + "/history.php?action=showgraph&itemids[]=" + identifier
+	return zabbix.basicURL +
+		"/history.php?action=showgraph&itemids%5B%5D=" + identifier
 }
 
 func (zabbix *Zabbix) call(


### PR DESCRIPTION
Following features are added:

* url-encode '[]' in the urls to suck less with terminal urlselect;
* substitute '$N' strings in the item names with proper values;
* (!) `-d` `-dd` `-ddd` flags for the providing more info about triggers (last
  item value, last item change, item description);
* (!) `--stacked` and `--normal` to obtain links to the stacked and normal
  composition graphs.

  umbermensch usage: `xdg-open $(zabbixctl -L 'rabota-es-*' /cpu usage from quota --stacked)`