### PR TITLE
show hostname in triggers

### DIFF
--- a/handle_triggers.go
+++ b/handle_triggers.go
@@ -92,7 +92,7 @@ func handleTriggers(
 			trigger.Severity(),
 			trigger.StatusProblem(),
 			trigger.StatusAcknowledge(),
-			trigger.Hostname,
+			trigger.GetHostName(),
 			trigger.Description,
 		)
 

--- a/trigger.go
+++ b/trigger.go
@@ -31,7 +31,10 @@ func (trigger *Trigger) String() string {
 }
 
 func (trigger *Trigger) GetHostName() string {
-	return trigger.Hosts[0].Name
+    if len(trigger.Hosts) > 0 {
+		return trigger.Hosts[0].Name
+    }
+    return "<missing>"
 }
 
 func (trigger *Trigger) StatusAcknowledge() string {

--- a/trigger.go
+++ b/trigger.go
@@ -18,12 +18,20 @@ type Trigger struct {
 		ID           string `json:"eventid"`
 		Acknowledged string `json:"acknowledged"`
 	} `json:"lastEvent"`
+	Hosts []struct {
+		Hostid string `json:"hostid"`
+		Name   string `json:"name"`
+	} `json:"hosts"`
 	Priority string `json:"priority"`
 }
 
 func (trigger *Trigger) String() string {
 	return trigger.LastEvent.ID + " " +
 		trigger.Hostname + " " + trigger.Description
+}
+
+func (trigger *Trigger) GetHostName() string {
+	return trigger.Hosts[0].Name
 }
 
 func (trigger *Trigger) StatusAcknowledge() string {


### PR DESCRIPTION
Add GetHostName() function to Trigger which will return the first hostname (and in general the only) attached to the trigger. Print the hostname to stdout by using the trigger.GetHostName function rather than the empty Hostname field.

Closes kovetskiy/zabbixctl#9