### PR TITLE
add mandatory (zabbix 3.4.2) parameter message in acknowledge function.

### DIFF
--- a/zabbix.go
+++ b/zabbix.go
@@ -169,7 +169,10 @@ func (zabbix *Zabbix) Acknowledge(identifiers []string) error {
 
 	err := zabbix.call(
 		"event.acknowledge",
-		Params{"eventids": identifiers},
+		Params{
+			"eventids": identifiers,
+			"message":  "ack",
+		},
 		&response,
 	)
 	if err != nil {


### PR DESCRIPTION
In api zabbix <= 2.4 there is no verification of the message parameter in the function acknowledge.
But in api zabbix-3.4 the message parameter is checked.
I added message = "ack" in function Acknowledge.

```
zabbixctl --since 70 -T -p -y -k /sda 43
:: Requesting information about statuses of triggers  
5669  2017-11-03 22:21:35  AVG  PROBLEM  NACK  forere.cname.s  SMART /dev/sdb -d sat SATA SSD mediaWearoutIndicator 43 %
5452  2017-11-02 13:57:20  AVG  PROBLEM  NACK  forevo.cname.s  SMART /dev/sdb -d sat SATA SSD mediaWearoutIndicator 43 %
5447  2017-11-02 13:37:19  AVG  PROBLEM  NACK  forevo.cname.s  SMART /dev/sda -d sat SATA SSD mediaWearoutIndicator 43 %

:: Proceed with acknowledge? [Y/n]: y
:: Acknowledging specified triggers  
can't acknowledge triggers [5669 5452 5447]
└─ zabbix returned error while working with api method event.acknowledge
   └─ Invalid params.
      └─ Incorrect arguments passed to function.
```

zabbix-3.4/frontends/php/include/classes/api/services/CEvent.php
```
441         public function acknowledge(array $data) {
442                 $data['eventids'] = zbx_toArray($data['eventids']);
443 
444                 $this->validateAcknowledge($data);
445 
...
530         protected function validateAcknowledge(array $data) {
531                 $dbfields = ['eventids' => null, 'message' => null];
532 
533                 if (!check_db_fields($dbfields, $data)) {
534                         self::exception(ZBX_API_ERROR_PARAMETERS, _('Incorrect arguments passed to function.'));
535                 }
```
zabbix-3.4/frontends/php/include/db.inc.php
```
 749 function check_db_fields($dbFields, &$args) {
 750         if (!is_array($args)) {
 751                 return false;
 752         }
 753 
 754         foreach ($dbFields as $field => $def) {
 755                 if (!isset($args[$field])) {
 756                         if (is_null($def)) {
 757                                 return false;
 758                         }
 759                         else {
 760                                 $args[$field] = $def;
 761                         }
 762                 }
 763         }
 764 
 765         return true;
 766 }
```