### PR TITLE
Fix docopt short option "since": -e -> -s.

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -151,7 +151,7 @@ Options:
     -x --severity
     -p --problem
     -t --recent
-    -e --since <date>    [default: 7 days ago]
+    -s --since <date>    [default: 7 days ago]
     -u --until <date>
     -m --maintenance
     -i --sort <fields>   [default: lastchange,priority]


### PR DESCRIPTION
docs.go
```
 58     -s --since <date>
 59       Show triggers that have changed their state after the given time.
 60       [default: 7 days ago]
...
154     -e --since <date>    [default: 7 days ago]
```