### PR TITLE
Replace github.com/simplereach/timeutils for windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /zabbixctl
+/zabbixctl.exe
 /zabbixctl.test

--- a/handle_maintenances.go
+++ b/handle_maintenances.go
@@ -7,11 +7,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/olekukonko/tablewriter"
 	karma "github.com/reconquest/karma-go"
-	"github.com/simplereach/timeutils"
 )
 
 func handleMaintenances(
@@ -613,31 +611,6 @@ func createTimeperiod(
 	timeperiod.Period = strconv.FormatInt(int64(periodSeconds), 10)
 
 	return timeperiod, strconv.FormatInt(int64(activeTill), 10), nil
-}
-
-func parseDate(date string) (int64, error) {
-
-	var dateUnix int64
-
-	destiny := karma.Describe("method", "parseDate")
-
-	if date == "" {
-		timeNow := time.Now()
-		dateUnix = timeNow.Unix()
-	} else {
-		dateParse, err := timeutils.ParseDateString(date)
-		if err != nil {
-			return dateUnix, destiny.Describe(
-				"error", err,
-			).Describe(
-				"date", date,
-			).Reason(
-				"can't convert date to unixtime",
-			)
-		}
-		dateUnix = dateParse.Unix()
-	}
-	return dateUnix, nil
 }
 
 func parsePeriod(targets string) (int64, error) {

--- a/handle_triggers.go
+++ b/handle_triggers.go
@@ -7,7 +7,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/reconquest/karma-go"
-	"github.com/simplereach/timeutils"
 )
 
 type ExtendedOutput int
@@ -255,15 +254,6 @@ func parseParams(args map[string]interface{}) (Params, error) {
 	}
 
 	return params, err
-}
-
-func parseDateTime(value string) (int64, error) {
-	date, err := timeutils.ParseDateString(value)
-	if err != nil {
-		return 0, karma.Format(err, "can't parse datetime '%s'", value)
-	}
-
-	return date.Unix(), nil
 }
 
 func confirmAcknowledge() bool {

--- a/parse_date_linux.go
+++ b/parse_date_linux.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"time"
+
+	karma "github.com/reconquest/karma-go"
+	"github.com/simplereach/timeutils"
+)
+
+func parseDate(date string) (int64, error) {
+
+	var dateUnix int64
+
+	destiny := karma.Describe("method", "parseDate")
+
+	if date == "" {
+		timeNow := time.Now()
+		dateUnix = timeNow.Unix()
+	} else {
+		dateParse, err := timeutils.ParseDateString(date)
+		if err != nil {
+			return dateUnix, destiny.Describe(
+				"error", err,
+			).Describe(
+				"date", date,
+			).Reason(
+				"can't convert date to unixtime",
+			)
+		}
+		dateUnix = dateParse.Unix()
+	}
+	return dateUnix, nil
+}
+
+func parseDateTime(value string) (int64, error) {
+	date, err := timeutils.ParseDateString(value)
+	if err != nil {
+		return 0, karma.Format(err, "can't parse datetime '%s'", value)
+	}
+
+	return date.Unix(), nil
+}

--- a/parse_date_windows.go
+++ b/parse_date_windows.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"time"
+
+	karma "github.com/reconquest/karma-go"
+)
+
+func parseDate(date string) (int64, error) {
+
+	var dateUnix int64
+
+	destiny := karma.Describe("method", "parseDate")
+
+	if date == "" {
+		timeNow := time.Now()
+		dateUnix = timeNow.Unix()
+	} else {
+		const RFC3339 = "2006-01-02 15:04"
+		dateParse, err := time.Parse(RFC3339, date)
+		if err != nil {
+			return dateUnix, destiny.Describe(
+				"error", err,
+			).Describe(
+				"date", date,
+			).Reason(
+				"can't convert date to unixtime",
+			)
+		}
+		dateUnix = dateParse.Unix()
+	}
+	return dateUnix, nil
+}
+
+func parseDateTime(value string) (int64, error) {
+	const RFC3339 = "2006-01-02 15:04"
+	date, err := time.Parse(RFC3339, value)
+	if err != nil {
+		return 0, karma.Format(err, "can't parse datetime '%s'", value)
+	}
+
+	return date.Unix(), nil
+}


### PR DESCRIPTION
Hi @kovetskiy ,

This replace the [timeutils](https://github.com/simplereach/timeutils) wrapper with the native function *time.Parse*. This allow compiling on windows, together with [#1](https://github.com/kovetskiy/spinner-go/pull/1) 

I hope I can get both merged, and let me know if you have any thought.