### PR TITLE
change user.login call to use username, not (deprecated) user

### DIFF
--- a/zabbix.go
+++ b/zabbix.go
@@ -187,7 +187,7 @@ func (zabbix *Zabbix) Login(username, password string) error {
 
 	err := zabbix.call(
 		"user.login",
-		Params{"user": username, "password": password},
+		Params{"username": username, "password": password},
 		&response,
 		withAuthFlag,
 	)


### PR DESCRIPTION
In Zabbix 5.2, the "user" property in user.login was deprecated in favor of "username", and was removed entirely in 6.4.

See https://www.zabbix.com/documentation/current/en/manual/api/reference/user/login and https://support.zabbix.com/browse/ZBXNEXT-8085